### PR TITLE
Add a Nix Flake to be able to compile the binary more easily on Linux / NixOS

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,82 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1773122722,
+        "narHash": "sha256-FIqHByVqxCprNjor1NqF80F2QQoiiyqanNNefdlvOg4=",
+        "owner": "Nixos",
+        "repo": "nixpkgs",
+        "rev": "62dc67aa6a52b4364dd75994ec00b51fbf474e50",
+        "type": "github"
+      },
+      "original": {
+        "owner": "Nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1773284828,
+        "narHash": "sha256-0qI+a9z7KpYCBbp4ENN32b2tf0VmC3MhgFw1KAroqxQ=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "2b18fe48d9a8a4ff3850d56b67cfe72f2a589237",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,53 @@
+{
+  description = "Rust cross-compilation environment for RustPotato";
+
+  inputs = {
+    nixpkgs.url = "github:Nixos/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+    rust-overlay = {
+      url = "github:oxalica/rust-overlay";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs = {
+    nixpkgs,
+    flake-utils,
+    rust-overlay,
+    ...
+  }:
+    flake-utils.lib.eachDefaultSystem (
+      system: let
+        overlays = [(import rust-overlay)];
+        pkgs = import nixpkgs {
+          inherit system overlays;
+        };
+
+        # Set the build target
+        rustTarget = "x86_64-pc-windows-gnu";
+
+        # Use nightly-2025-02-14 as build toolchain
+        rustToolchain = pkgs.rust-bin.nightly."2025-02-14".default.override {
+          extensions = ["rust-src"];
+          targets = [rustTarget];
+        };
+
+        # Define variables to use mingwW64 stdenv within buildInputs
+        mingwPkgs = pkgs.pkgsCross.mingwW64;
+        mingwCc = mingwPkgs.stdenv.cc;
+      in {
+        devShells.default = pkgs.mkShell {
+          buildInputs = [
+            rustToolchain
+
+            # Use the Windows cross-compiler and pthreads
+            mingwCc
+            mingwPkgs.windows.pthreads
+          ];
+
+          # Set the default build target to the rustTarget so we don't need --target
+          CARGO_BUILD_TARGET = rustTarget;
+        };
+      }
+    );
+}


### PR DESCRIPTION
Hello and first of all: Thanks for the Rust port of GodPotato!

I added a Nix Flake (`flake.nix`) to the project, to be able to build RustPotato with the intended toolchain (`nightly-2025-02-14`) more easily on Linux / NixOS.

To enter the development environment, one can simply execute `nix develop` with `nix` installed:

```console
[purpole@pc:~/RustPotato]$ nix develop
```

Inside the development environment, the Rust toolchain is installed & set up and the binary can be compiled like so:

```console
[purpole@pc:~/RustPotato]$ cargo build --release
   Compiling proc-macro2 v1.0.92
   Compiling unicode-ident v1.0.14
   Compiling windows-link v0.1.1
   Compiling libc v0.2.169
   Compiling winapi-x86_64-pc-windows-gnu v0.4.0
   Compiling winapi v0.3.9
   Compiling byteorder v1.5.0
   Compiling base64 v0.22.1
   Compiling windows-strings v0.4.0
   Compiling windows-result v0.3.2
   Compiling libc-print v0.1.23
   Compiling quote v1.0.38
   Compiling syn v2.0.92
   Compiling windows-implement v0.60.0
   Compiling windows-interface v0.59.1
   Compiling windows-core v0.61.0
   Compiling windows-numerics v0.2.0
   Compiling windows-future v0.2.0
   Compiling windows-collections v0.2.0
   Compiling windows v0.61.1
   Compiling RustPotato v0.1.0
    Finished `release` profile [optimized] target(s)
```

Quick test on Windows 11 shows it works:

<img width="761" height="379" alt="whoami" src="https://github.com/user-attachments/assets/ccb2fa02-61b6-4d1d-913c-26d8ff194f0c" />
